### PR TITLE
Allow enabling both dynamic and file type tags files 

### DIFF
--- a/autoload/xolox/easytags.vim
+++ b/autoload/xolox/easytags.vim
@@ -484,15 +484,21 @@ endfunction
 
 function! xolox#easytags#get_tagsfile() " {{{2
   let tagsfile = expand(g:easytags_file)
-  if !empty(g:easytags_by_filetype) && !empty(&filetype)
-    let directory = xolox#misc#path#absolute(g:easytags_by_filetype)
-    let tagsfile = xolox#misc#path#merge(directory, &filetype)
-  elseif g:easytags_dynamic_files
+
+  if g:easytags_dynamic_files
     let files = tagfiles()
     if len(files) > 0
       let tagsfile = files[0]
     endif
   endif
+
+  if !empty(g:easytags_by_filetype) && !empty(&filetype)
+    if !g:easytags_dynamic_files || filewritable(tagsfile) != 1
+      let directory = xolox#misc#path#absolute(g:easytags_by_filetype)
+      let tagsfile = xolox#misc#path#merge(directory, &filetype)
+    endif
+  endif
+
   if filereadable(tagsfile) && filewritable(tagsfile) != 1
     let message = "The tags file %s isn't writable!"
     throw printf(message, fnamemodify(tagsfile, ':~'))

--- a/doc/easytags.txt
+++ b/doc/easytags.txt
@@ -139,6 +139,10 @@ When you enable this option, the easytags plug-in will use the first filename
 returned by |tagfiles()| as the tags file to write. Note that 'tagfiles()' is
 reevaluated every time the plug-in runs.
 
+NOTE: If you've also enabled |g:easytags_by_filetype| the project specific tags
+file must exist, even if it's empty; Otherwise |g:easytags_by_filetype| will take
+precedence.
+
 -------------------------------------------------------------------------------
 The *g:easytags_by_filetype* option
 
@@ -151,7 +155,12 @@ existing directory. The easytags plug-in will create separate tags files for
 each file type in the configured directory. These tags files are automatically
 registered by the easytags plug-in when the file type of a buffer is set.
 
-Note that if you already have a global tags file you can create file type
+If you've also enabled |g:easytags_dynamic_files| and the project specific tags
+file exists, and is writable, it will take precedence. If the project specific
+tags file doesn't exist you can indicate you want to use project specific tags
+by creating it.
+
+Note: If you already have a global tags file you can create file type
 specific tags files from the global tags file using the command
 ':TagsByFileType'.
 


### PR DESCRIPTION
When both options are enabled, project specific tags files take precedence if they exist and are writable, otherwise a file type tags file is used.
