### PR TITLE
Do not highlight tags on :UpdateTags when it is configured off.

### DIFF
--- a/autoload/xolox/easytags.vim
+++ b/autoload/xolox/easytags.vim
@@ -120,7 +120,7 @@ function! xolox#easytags#update(silent, filter_tags, filenames) " {{{2
     endif
     " When :UpdateTags was executed manually we'll refresh the dynamic
     " syntax highlighting so that new tags are immediately visible.
-    if !a:silent
+    if !a:silent && xolox#misc#option#get('easytags_auto_highlight', 1)
       HighlightTags
     endif
     return 1


### PR DESCRIPTION
I turn off highlighting of tags (`:let g:easytags_auto_highlight = 0`), because I usually have very large tags databases. When I manually trigger an update via `:UpdateTags`, the highlighting is processed, though, resulting in the long delay or "regexp too long" error. The`:UpdateTags` command should honor the configuration setting.
