### PR TITLE
FIX: Prevent cache corruption by moving before tags write.

### DIFF
--- a/autoload/xolox/easytags.vim
+++ b/autoload/xolox/easytags.vim
@@ -246,15 +246,17 @@ function! s:filter_merge_tags(filter_tags, tagsfile, output, context) " {{{3
     call filter(entries, join(filters, ' && '))
   endif
   let num_filtered = num_old_entries - len(entries)
-  " Merge old/new tags and write tags file.
+  " Merge old/new tags.
   call extend(entries, a:output)
+  " We've already read the tags file, cache the tagged files before the entries
+  " get flattened by the write.
+  let fname = s:canonicalize(a:tagsfile, a:context)
+  call s:cache_tagged_files_in(fname, getftime(fname), entries, a:context)
+  " And write tags file.
   if !xolox#easytags#write_tagsfile(a:tagsfile, headers, entries)
     let msg = "Failed to write filtered tags file %s!"
     throw printf(msg, fnamemodify(a:tagsfile, ':~'))
   endif
-  " We've already read the tags file, might as well cache the tagged files :-)
-  let fname = s:canonicalize(a:tagsfile, a:context)
-  call s:cache_tagged_files_in(fname, getftime(fname), entries, a:context)
   return num_filtered
 endfunction
 


### PR DESCRIPTION
A side effect of `xolox#easytags#write_tagsfile()` is that the entries argument is joined together. This then causes problems in `s:cache_tagged_files_in()`, where the filename element is addressed via `entry[1]`. When the entries have been flattened, this accesses a single character, and then the cache is corrupted.

To fix this, move the cache update before the writing of the tags file. This avoids the need to make a copy of the entries before flattening them.
