### PR TITLE
ENH: Avoid tag updating when ctags output has identical fingerprint.

### DIFF
--- a/autoload/xolox/easytags.vim
+++ b/autoload/xolox/easytags.vim
@@ -222,6 +222,11 @@ endif
 
 let s:fingerprints = {}
 function! s:has_updates(cfile, output)
+  if empty(a:cfile)
+    " The cache doesn't work when tags aren't created for the current file.
+    return 1
+  endif
+
   let fingerprint = s:get_fingerprint(a:cfile, a:output)
   if ! empty(fingerprint) && get(s:fingerprints, a:cfile, '') ==# fingerprint
     return 0


### PR DESCRIPTION
We can avoid the lengthy and blocking update of the tags database when the ctags output returns the same information as before; i.e. nothing tag-relevant has been changed since the last update.
Since 7.3.816, Vim has a `sha256()` function that allows us to quickly calculate a fingerprint over the ctags output. When that is not available, only handle the special case of a (covered) file that has no tags at all (as calculating a hash in Vimscript is costly and would probably defeat the intended speedup).
