### PR TITLE
Fix (t)csh system call (from CheckCtags) stdout, stderr redirection 

### DIFF
--- a/autoload/xolox/misc/os.vim
+++ b/autoload/xolox/misc/os.vim
@@ -38,7 +38,7 @@ function! xolox#misc#os#exec(options) " {{{1
     if !async
       let tempout = tempname()
       let temperr = tempname()
-      let cmd = printf('(%s) 1>%s 2>%s', cmd,
+      let cmd = printf('sh -c "(%s) 1>%s 2>%s"', cmd,
             \ xolox#misc#escape#shell(tempout),
             \ xolox#misc#escape#shell(temperr))
     endif


### PR DESCRIPTION
Create system-call 'cmd' to call sh -c "..." in order to internally call bash, in case (t)csh is used as default shell.
