### PR TITLE
Java interfaces support

### DIFF
--- a/autoload/xolox/easytags.vim
+++ b/autoload/xolox/easytags.vim
@@ -1052,11 +1052,17 @@ call xolox#easytags#define_tagkind({
 
 call xolox#easytags#define_tagkind({
       \ 'filetype': 'java',
+      \ 'hlgroup': 'javaInterface',
+      \ 'tagkinds': 'i'})
+
+call xolox#easytags#define_tagkind({
+      \ 'filetype': 'java',
       \ 'hlgroup': 'javaMethod',
       \ 'tagkinds': 'm'})
 
 highlight def link javaClass Identifier
 highlight def link javaMethod Function
+highlight def link javaInterface Identifier
 
 " C#. {{{2
 


### PR DESCRIPTION
This commit adds support for highlighting java interfaces. I'm working with ctags-5.8 where java interfaces are marked with 'i' and are not recognized by the plugin.
