### PR TITLE
Replace \0 by \g<0> in python sub

### DIFF
--- a/misc/easytags/highlight.py
+++ b/misc/easytags/highlight.py
@@ -5,7 +5,7 @@ syntax highlighting by reimplementing tag file reading and :syntax command
 generation in Python with a focus on doing the least amount of work.
 
 Author: Peter Odding <peter@peterodding.com>
-Last Change: August 31, 2013
+Last Change: March 8, 2014
 URL: http://peterodding.com/code/vim/easytags
 '''
 
@@ -39,7 +39,7 @@ def easytags_gensyncmd(tagsfiles, filetype, tagkinds, syntaxgroup, prefix, suffi
     counter, limit = 0, 1024 * 20
     to_escape = re.compile(r'[.*^$/\\~\[\]]')
     for ident in matches.keys():
-        escaped = to_escape.sub(r'\\\0', ident)
+        escaped = to_escape.sub(r'\\\g<0>', ident)
         patterns.append(escaped)
         counter += len(escaped)
         if counter > limit:


### PR DESCRIPTION
> The back reference `\g<0>` substitutes in the entire substring matched by the RE.
> http://docs.python.org/2/library/re.html#re.sub

The documentation does not mention`\0` as an alias to it (although `\1` to `\9` works). I guess this alias (`\0` <=> `\g<0>`) existed in old python versions but it is not the case any more.

In python 2.7 and 3.3:

``` python
> import re; re.compile(r'123').sub(r'@\0@',"ab123cd")
'ab@\x00@cd' # KO
> import re; re.compile(r'123').sub(r'@\g<0>@',"ab123cd")
'ab@123@cd' # OK
```
