### PR TITLE
Temporarily disable automatic update during :vimgrep.

### DIFF
--- a/autoload/xolox/easytags.vim
+++ b/autoload/xolox/easytags.vim
@@ -39,6 +39,10 @@ let s:last_automatic_run = 0
 
 function! xolox#easytags#autoload(event) " {{{2
   try
+    if xolox#misc#option#get('easytags_auto_disabled', 0)
+      call xolox#misc#msg#debug("easytags.vim %s: Skipping update because it is temporarily disabled.", g:xolox#easytags#version)
+      return
+    endif
     if exists('g:SessionLoad') && a:event == 'BufReadPost'
       " If a session is being loaded, we won't update the tags for files that
       " are loaded in the session because this disrupts the session loading...

--- a/plugin/easytags.vim
+++ b/plugin/easytags.vim
@@ -168,6 +168,11 @@ augroup PluginEasyTags
   " After reloading a buffer the dynamic syntax highlighting is lost. The
   " following code makes sure the highlighting is refreshed afterwards.
   autocmd BufReadPost * unlet! b:easytags_last_highlighted
+  " During :vimgrep, each searched buffer triggers an asynchronous tag update,
+  " resulting in races for the tags file. Temporarily disable the automatic
+  " updates during this.
+  autocmd QuickFixCmdPre  *vimgrep* let g:easytags_auto_disabled = 1
+  autocmd QuickFixCmdPost *vimgrep* let g:easytags_auto_disabled = 0
 augroup END
 
 " }}}1


### PR DESCRIPTION
During :vimgrep, each searched buffer triggers an asynchronous tag update, resulting in races for the tags file. Temporarily disable the automatic updates during this, through a global g:easytags_auto_disabled flag.
