### PR TITLE
FIX: Ensure full absolute tagsfile filespec in async mode.

### DIFF
--- a/autoload/xolox/easytags.vim
+++ b/autoload/xolox/easytags.vim
@@ -173,7 +173,7 @@ function! xolox#easytags#update(silent, filter_tags, filenames) " {{{2
       let params['directory'] = xolox#misc#path#absolute(g:easytags_by_filetype)
       let params['filetypes'] = g:xolox#easytags#filetypes#ctags_to_vim
     else
-      let params['tagsfile'] = tagsfile
+      let params['tagsfile'] = (async ? fnamemodify(tagsfile, ':p') : tagsfile) " Need to pass full absolute path to the forked process.
     endif
     if async
       call xolox#misc#async#call({'function': 'xolox#easytags#update#with_vim', 'arguments': [params], 'callback': 'xolox#easytags#async_callback'})


### PR DESCRIPTION
On Windows, `tagfiles()` can return a filespec that is absolute to the current drive (i.e. `\foo\bar\tags`). In async mode, the forked Vim process may have another current drive, so it should be ensured that the filespec is a full one, including the drive letter: `D:\foo\bar\tags`.

You can also see this issue in the debug output of #85.
