### PR TITLE
FIX: Avoid error about empty Dictionary key.

### DIFF
--- a/autoload/xolox/easytags/update.vim
+++ b/autoload/xolox/easytags/update.vim
@@ -254,6 +254,9 @@ endfunction
 function! s:create_cache() " {{{1
   let cache = {'canonicalize_cache': {}, 'exists_cache': {}}
   function cache.canonicalize(pathname) dict
+    if a:pathname == ''
+      return ''
+    endif
     if !has_key(self, a:pathname)
       let self[a:pathname] = xolox#easytags#utils#canonicalize(a:pathname)
     endif


### PR DESCRIPTION
I had a degenerate tags file that had _two_ tabs separating the tag from the filespec column; parsing that yields an empty filespec, which caused E713. There used to be an explicit check for that; with your recent refactorings, one instance of that check was lost. Here it is again!
