### PR TITLE
Add g:easytags_suppress_report option

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,12 @@ If this is set and not false, it will suppress the warning on startup if ctags i
 
     :let g:easytags_suppress_ctags_warning = 1
 
+### The `g:easytags_suppress_report` option
+
+If this is set and not false, it will suppress the report displayed on tag updates.
+
+    :let g:easytags_suppress_report = 1
+
 ## Customizing the easytags plug-in
 
 Advanced users may wish to customize how the easytags plug-in works beyond the point of changing configuration defaults. This section contains some hints about this. If you have suggestions, please feel free to submit them.

--- a/autoload/xolox/easytags.vim
+++ b/autoload/xolox/easytags.vim
@@ -192,7 +192,9 @@ function! xolox#easytags#update(silent, filter_tags, filenames) " {{{2
     if async
       call xolox#misc#async#call({'function': 'xolox#easytags#update#with_vim', 'arguments': [params], 'callback': 'xolox#easytags#async_callback'})
     else
-      call s:report_results(xolox#easytags#update#with_vim(params), 0)
+      if !(exists('g:easytags_suppress_report') && g:easytags_suppress_report)
+        call s:report_results(xolox#easytags#update#with_vim(params), 0)
+      endif
       " When :UpdateTags was executed manually we'll refresh the dynamic
       " syntax highlighting so that new tags are immediately visible.
       if !a:silent && xolox#misc#option#get('easytags_auto_highlight', 1)
@@ -500,10 +502,12 @@ function! xolox#easytags#syntax_groups_to_ignore() " {{{2
 endfunction
 
 function! xolox#easytags#async_callback(response) " {{{2
-  if has_key(a:response, 'result')
-    call s:report_results(a:response['result'], 1)
-  else
-    call xolox#misc#msg#warn("easytags.vim %s: Asynchronous tags file update failed! (%s at %s)", g:xolox#easytags#version, a:response['exception'], a:response['throwpoint'])
+  if !(exists('g:easytags_suppress_report') && g:easytags_suppress_report)
+    if has_key(a:response, 'result')
+      call s:report_results(a:response['result'], 1)
+    else
+      call xolox#misc#msg#warn("easytags.vim %s: Asynchronous tags file update failed! (%s at %s)", g:xolox#easytags#version, a:response['exception'], a:response['throwpoint'])
+    endif
   endif
 endfunction
 

--- a/doc/easytags.txt
+++ b/doc/easytags.txt
@@ -27,6 +27,7 @@ Contents ~
   15. The |g:easytags_include_members| option
   16. The |g:easytags_resolve_links| option
   17. The |g:easytags_suppress_ctags_warning| option
+  18. The |g:easytags_suppress_report| option
  5. Customizing the easytags plug-in             |customizing-easytags-plug-in|
   1. Passing custom command line arguments to Exuberant Ctags |easytags-passing-custom-command-line-arguments-to-exuberant-ctags|
   2. Update & highlight tags immediately after save |easytags-update-highlight-tags-immediately-after-save|
@@ -467,6 +468,14 @@ If this is set and not false, it will suppress the warning on startup if ctags
 is not found or not recent enough.
 >
   :let g:easytags_suppress_ctags_warning = 1
+<
+-------------------------------------------------------------------------------
+The *g:easytags_suppress_report* option
+
+If this is set and not false, it will suppress the report displayed on tag
+updates.
+>
+  :let g:easytags_suppress_report = 1
 <
 ===============================================================================
                                                  *customizing-easytags-plug-in*


### PR DESCRIPTION
Currently, easytags reports the tag file update status. This feature is disabled by default on async mode, but is enabled on sync mode. The problem is that this message overwrites other vim messages. As a result, if I save a file and switch into insert mode, I cannot see `--INSERT--` string.

`g:easytags_suppress_report` works pretty much similar to `g:easytags_suppress_ctags_warning` option. If this variable is set and true, easytags does not print the update status.
